### PR TITLE
replace all environment_tyoe with environment_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ def test_snap_gateway():
     client = Client(
         client_key="Vt-Client-Key",
         server_key="Vt-Server-Key",
-        environment_tyoe=PRODUCTION
+        environment_type=PRODUCTION
     )
 
     snap = gateway.Snap(client=client)
@@ -36,7 +36,7 @@ Alternatively you may construct your own snap request:
     client = Client(
         client_key="Vt-Client-Key",
         server_key="Vt-Server-Key",
-        environment_tyoe=PRODUCTION
+        environment_type=PRODUCTION
     )
 
     snap = gateway.Snap(client=client)

--- a/example/simplepay/web.py
+++ b/example/simplepay/web.py
@@ -9,7 +9,7 @@ app = Flask(__name__)
 midtrans_client = Client(
     client_key="VT-client-IKktHiy3aRYHljsw",
     server_key="VT-server-7CVlR3AJ8Dpkez3k_TeGJQZU",
-    environment_tyoe=SANDBOX
+    environment_type=SANDBOX
 )
 
 @app.route('/')

--- a/midtrans/client.py
+++ b/midtrans/client.py
@@ -11,9 +11,9 @@ class Client:
     def __init__(self,
                  client_key,
                  server_key,
-                 environment_tyoe=SANDBOX):
+                 environment_type=SANDBOX):
 
-        self.environment_type = environment_tyoe
+        self.environment_type = environment_type
         self.client_key = client_key
         self.server_key = server_key
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -4,7 +4,7 @@ def test_snap_gateway():
     client = Client(
         client_key="Vt-Client-Key",
         server_key="Vt-Server-Key",
-        environment_tyoe=PRODUCTION
+        environment_type=PRODUCTION
     )
 
     snap = gateway.Snap(client=client)


### PR DESCRIPTION
`environment_tyoe` made us confused. At first we though the documentation was typo, but when we check the code it is using `tyoe`. 

On the `Client` class, the constructor parameter was refer to `tyoe` but the assignment refer to `type`.

We use `rg` to replace all tyoe into type.

```
rg environment_tyoe -l | xargs perl -pi -E 's/environment_tyoe/environment_type/g'
```
or ack
```
ack -l environment_tyoe | xargs perl -pi -E 's/environment_tyoe/environment_type/g'
```